### PR TITLE
Update locals.tf to include vault creds

### DIFF
--- a/templates/k8s/base/locals.tf.j2
+++ b/templates/k8s/base/locals.tf.j2
@@ -2,3 +2,22 @@ locals {
   juju_model_name = "{{ env_name }}"
   cloud_name      = "{{ env_cloud }}"
 }
+
+variable "approle_role_id" {
+  description = "Approle Role ID"
+  type        = string
+  validation {
+    condition     = var.approle_role_id != null
+    error_message = "No value set for approle_role_id: Set it, or export TF_VAR_APPROLE_ROLE_ID."
+  }
+}
+
+
+variable "approle_secret_id" {
+  description = "Approle Secret ID"
+  type        = string
+  validation {
+    condition     = var.approle_secret_id != null
+    error_message = "No value set for approle_secret_id: Set it, or export TF_VAR_APPROLE_SECRET_ID."
+  }
+}

--- a/templates/machine/base/locals.tf.j2
+++ b/templates/machine/base/locals.tf.j2
@@ -2,3 +2,22 @@ locals {
   juju_model_name = "{{ env_name }}"
   cloud_name      = "{{ env_cloud }}"
 }
+
+variable "approle_role_id" {
+  description = "Approle Role ID"
+  type        = string
+  validation {
+    condition     = var.approle_role_id != null
+    error_message = "No value set for approle_role_id: Set it, or export TF_VAR_APPROLE_ROLE_ID."
+  }
+}
+
+
+variable "approle_secret_id" {
+  description = "Approle Secret ID"
+  type        = string
+  validation {
+    condition     = var.approle_secret_id != null
+    error_message = "No value set for approle_secret_id: Set it, or export TF_VAR_APPROLE_SECRET_ID."
+  }
+}


### PR DESCRIPTION
### Description

Currently we're not including Vault creds in `locals.tf`, but this adds it for machine and k8s models.
