### PR TITLE
Update machine base templates

### DIFF
--- a/templates/machine/base/backend.tf.j2
+++ b/templates/machine/base/backend.tf.j2
@@ -6,13 +6,17 @@
 {% endif %}
 terraform {
   backend "s3" {
-    key                         = "environments/{{ env_owner }}/{{ env_name }}/application/state"
-    bucket                      = "{{ env_cloud }}-flux-tfstate"
+    key                         = "state"
+    bucket                      = "{{ env_name }}-tfstate"
     region                      = "{{ env_region }}"
-    endpoint                    = "radosgw.{{ env_cloud }}.canonical.com"
+    endpoints                   = {
+      s3 = "https://radosgw.{{ env_cloud }}.canonical.com"
+    }
     skip_region_validation      = true
     skip_credentials_validation = true
-    force_path_style            = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
   }
 }
 {% endfilter %}

--- a/templates/machine/base/locals.tf.j2
+++ b/templates/machine/base/locals.tf.j2
@@ -1,3 +1,0 @@
-locals {
-  juju_model_name = "{{ env_name }}"
-}

--- a/templates/machine/base/main.tf.j2
+++ b/templates/machine/base/main.tf.j2
@@ -1,1 +1,3 @@
-# main file
+locals {
+  juju_model_name = "{{ env_name }}"
+}

--- a/templates/machine/base/providers.tf.j2
+++ b/templates/machine/base/providers.tf.j2
@@ -1,12 +1,14 @@
 {#- CMDB: Controller addresses should be stored in a CMDB, not here. #}
 {% filter trim %}
 {% if env_stage == "production" %}
+{%     set controller = "prodstack-is" %}
 {%     if env_cloud == "ps5" %}
 {%         set controller_addresses = "10.131.1.106:17070,10.131.1.80:17070,10.131.1.171:17070" %}
 {%     elif env_cloud == "ps6" %}
 {%         set controller_addresses = "10.141.22.89:17070,10.141.22.175:17070,10.141.22.167:17070" %}
 {%     endif %}
 {% elif env_stage == "staging" %}
+{%     set controller = "prodstack-is-beta" %}
 {%     if env_cloud == "ps5" %}
 {%         set controller_addresses = "10.131.3.163:17070,10.131.3.171:17070,10.131.3.230:17070" %}
 {%     elif env_cloud == "ps6" %}
@@ -30,19 +32,18 @@ provider "vault" {
   }
 }
 
-data "vault_generic_secret" "juju-credentials" {
+data "vault_generic_secret" "juju_credentials" {
   path = "secret/{{ env_region }}/roles/{{ env_name }}/juju"
 }
 
-data "vault_generic_secret" "juju-controller-certificate" {
-  path = "secret/{{ env_region }}/juju/common/controller_ca_certs/{{ env_stage }}"
+data "vault_generic_secret" "juju_controller_certificate" {
+  path = "secret/{{ env_region }}/juju/common/ca_certs/{{ controller }}"
 }
 
 provider "juju" {
-  # These addresses refer to the {{ env_cloud }} controller for {{ env_stage }} environments
   controller_addresses = "{{ controller_addresses }}"
-  ca_certificate       = data.vault_generic_secret.juju-controller-certificate.data["ca_cert"]
-  username             = data.vault_generic_secret.juju-credentials.data["username"]
-  password             = data.vault_generic_secret.juju-credentials.data["password"]
+  ca_certificate       = data.vault_generic_secret.juju_controller_certificate.data["ca_cert"]
+  username             = data.vault_generic_secret.juju_credentials.data["username"]
+  password             = data.vault_generic_secret.juju_credentials.data["password"]
 }
 {% endfilter %}

--- a/templates/machine/base/variables.tf.j2
+++ b/templates/machine/base/variables.tf.j2
@@ -3,7 +3,7 @@ variable "approle_role_id" {
   type        = string
   validation {
     condition     = var.approle_role_id != null
-    error_message = "No value set for approle_role_id: Set it, or export TF_VAR_APPROLE_ROLE_ID."
+    error_message = "No value set for approle_role_id: Check that TF_VAR_approle_role_id has been exported."
   }
 }
 
@@ -13,6 +13,6 @@ variable "approle_secret_id" {
   type        = string
   validation {
     condition     = var.approle_secret_id != null
-    error_message = "No value set for approle_secret_id: Set it, or export TF_VAR_APPROLE_SECRET_ID."
+    error_message = "No value set for approle_secret_id: Check that TF_VAR_LOGIN_approle_secret_id has been exported."
   }
 }

--- a/templates/machine/base/versions.tf.j2
+++ b/templates/machine/base/versions.tf.j2
@@ -1,13 +1,13 @@
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.6.6"
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.12.0"
+      version = "~> 4.2.0"
     }
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.0"
+      version = "~> 0.10.1"
     }
   }
 }


### PR DESCRIPTION
Fix issues with machine base template
* Formatting for Terraform 1.6+
* Move locals into `main.tf` for simplification
* Update path to controller CA certs
* Fix error message for variable validation
* Bump default provider versions