### PR TITLE
feat: update base template to use 3.4 controllers for PS5

### DIFF
--- a/templates/common/base/providers.tf.j2
+++ b/templates/common/base/providers.tf.j2
@@ -2,16 +2,16 @@
 {% filter trim %}
 {% if env_stage == "production" %}
 {%     if env_cloud == "ps5" %}
-{%         set controller = "prodstack-is" %}
-{%         set controller_addresses = "10.131.1.106:17070,10.131.1.80:17070,10.131.1.171:17070" %}
+{%         set controller = "juju-controller-34-production-ps5" %}
+{%         set controller_addresses = "juju-controller-34-production-ps5.admin.canonical.com:17070" %}
 {%     elif env_cloud == "ps6" %}
 {%         set controller = "juju-controller-34-production-ps6" %}
 {%         set controller_addresses = "juju-controller-34-production-ps6.admin.canonical.com:17070" %}
 {%     endif %}
 {% elif env_stage == "staging" %}
 {%     if env_cloud == "ps5" %}
-{%         set controller = "prodstack-is-beta" %}
-{%         set controller_addresses = "10.131.3.163:17070,10.131.3.171:17070,10.131.3.230:17070" %}
+{%         set controller = "juju-controller-34-staging-ps5" %}
+{%         set controller_addresses = "juju-controller-34-staging-ps5.admin.canonical.com:17070" %}
 {%     elif env_cloud == "ps6" %}
 {%         set controller = "juju-controller-34-staging-ps6" %}
 {%         set controller_addresses = "juju-controller-34-staging-ps6.admin.canonical.com:17070" %}


### PR DESCRIPTION
### Description

Update the base template to make 3.4 controllers the default for PS5

### Type

- [ ] Fix issue <!-- provide the issue number in format #number like #123 -->
- [ ] Add template.
- [x] Change existing template.
- [ ] Other. Please describe bellow.
<!-- Describe type here if you choose Other -->
